### PR TITLE
Convert Write-Error to Write-Host due to aws PS SDK bug

### DIFF
--- a/PSGradient/GradientHelpers/PSInvokeGetServiceIds.ps1
+++ b/PSGradient/GradientHelpers/PSInvokeGetServiceIds.ps1
@@ -10,7 +10,7 @@ Function Invoke-GetServiceIds {
             }
             return $skuServiceIds
         } catch {
-            Write-Error $_
+            Write-Host $_
             throw 'An error occurred while getting service IDs. Script execution stopped.'
         }
     }

--- a/PSGradient/GradientHelpers/PSUpdateIntegrationStatus.ps1
+++ b/PSGradient/GradientHelpers/PSUpdateIntegrationStatus.ps1
@@ -5,7 +5,7 @@ Function Invoke-UpdateStatus {
             $response = Update-PSIntegrationStatus "pending"
             Write-Host "Response  ${response}"
         } catch {
-            Write-Error $_
+            Write-Host $_
             throw 'An error occurred while updating status. Script execution stopped.'
         }
     }

--- a/PSGradient/PSGradient.psm1
+++ b/PSGradient/PSGradient.psm1
@@ -11,7 +11,8 @@
 try {
     Add-Type -AssemblyName System.Web -ErrorAction Ignore | Out-Null
     Add-Type -AssemblyName System.Net -ErrorAction Ignore | Out-Null
-} catch {
+}
+catch {
     Write-Verbose $_
 }
 
@@ -21,7 +22,7 @@ $ErrorActionPreference = 'Stop'
 # store the API client's configuration
 $Script:Configuration = [System.Collections.HashTable]@{}
 
-$Script:CmdletBindingParameters = @('Verbose','Debug','ErrorAction','WarningAction','InformationAction','ErrorVariable','WarningVariable','InformationVariable','OutVariable','OutBuffer','PipelineVariable')
+$Script:CmdletBindingParameters = @('Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction', 'ErrorVariable', 'WarningVariable', 'InformationVariable', 'OutVariable', 'OutBuffer', 'PipelineVariable')
 
 'Api', 'Model', 'Client', 'Private' | Get-ChildItem -Path {
     Join-Path $PSScriptRoot $_
@@ -29,8 +30,9 @@ $Script:CmdletBindingParameters = @('Verbose','Debug','ErrorAction','WarningActi
     Write-Debug "Importing file: $($_.BaseName)"
     try {
         . $_.FullName
-    } catch {
-        Write-Error -Message "Failed to import function $($_.Fullname): $_"
+    }
+    catch {
+        Write-Host -Message "Failed to import function $($_.Fullname): $_"
     }
 }
 


### PR DESCRIPTION
Convert Write-Error to Write-host because aws Powershell SDK has a bug with Write-Error.